### PR TITLE
Potential fix for code scanning alert no. 1: Exposure of private files

### DIFF
--- a/directory-traversal-example.js
+++ b/directory-traversal-example.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const app = express();
-app.use(express.static(__dirname));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // VULNERABLE FUNCTION - SEND FILE WITH USER-SUPPLIED FILENAME
 function sendFileWithUserSuppliedName(res, filePath) {


### PR DESCRIPTION
Potential fix for [https://github.com/AlexBStan/THM-Snyk-Open-Source/security/code-scanning/1](https://github.com/AlexBStan/THM-Snyk-Open-Source/security/code-scanning/1)

To fix the problem, we should limit the directories that are served as static files to only those that are intended for public access. This can be done by specifying the exact folders that should be served, rather than serving the entire source root folder. In this case, we can create a dedicated folder for static files and serve only that folder.

- Create a new folder named `public` within the project directory.
- Move all static files that need to be publicly accessible into the `public` folder.
- Update the `express.static` middleware to serve only the `public` folder.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
